### PR TITLE
Initial commit

### DIFF
--- a/.github/workflows/auto-tagger.yml
+++ b/.github/workflows/auto-tagger.yml
@@ -1,0 +1,17 @@
+name: auto_tagger
+on:
+  pull_request:
+   types: [closed]
+jobs:
+  build:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Github PR Auto Tagger
+      uses: RueLaLa/auto-tagger@v2.1.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -1,0 +1,53 @@
+name: Base images
+on: pull_request
+env:
+  DOCKER_CLI_EXPERIMENTAL: 'enabled'
+jobs:
+  # Use un-authenticated ephemeral registry image uri for testing
+  ttl-sh:
+    runs-on: ubuntu-22.04
+    outputs:
+      uri: ${{ steps.image-uri.outputs.uri }}
+    steps:
+      - id: image-uri
+        run: echo "uri=ttl.sh/${{ github.repository }}/$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
+  test:
+    runs-on: ubuntu-22.04
+    needs: [ttl-sh]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: ./buildpacks/create-multi-arch-builders
+        with:
+          path: 'buildpacks/create-multi-arch-builders/testdata'
+          base-image-uri: ${{ needs.ttl-sh.outputs.uri }}
+      - name: Test mulit-arch builders
+        run: |
+          #!/usr/bin/env bash -euo pipefail
+
+          cd buildpacks/create-multi-arch-builders/testdata
+
+          # Gets tag from builder toml files following naming pattern `builder-<tag>.toml`
+          tags=$(ls *.toml | xargs -n1 | cut -d- -f2 | cut -d. -f1 | xargs)
+
+          set -x
+
+          for tag in $tags; do
+              image_tag="${{ needs.ttl-sh.outputs.uri }}:${tag}"
+              docker buildx build \
+                  --platform linux/amd64,linux/arm64 \
+                  --tag not-pushing-so-this-is-ignored \
+                  - <<TEST-MULTI-ARCH-BUILDER-EOF
+          RUN <<RUN_EOF
+          set -x
+
+          arch
+
+          # Basic tests that verifies lifecycle binary works on this platform
+          docker run --rm ${image_tag} arch
+          docker run --rm ${image_tag} /cnb/lifecycle/lifecycle -version
+          RUN_EOF
+          TEST-MULTI-ARCH-BUILDER-EOF
+
+          done

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -40,7 +40,7 @@ jobs:
                   --tag not-pushing-so-this-is-ignored \
                   - <<TEST-DOCKERFILE-EOF
           FROM ${image_tag}
-          RUN arch && /cnb/lifecycle/lifecycle -version
+          RUN /cnb/lifecycle/lifecycle -version
           TEST-DOCKERFILE-EOF
 
           done

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -38,16 +38,9 @@ jobs:
               docker buildx build \
                   --platform linux/amd64,linux/arm64 \
                   --tag not-pushing-so-this-is-ignored \
-                  - <<TEST-MULTI-ARCH-BUILDER-EOF
-          RUN <<RUN_EOF
-          set -x
-
-          arch
-
-          # Basic tests that verifies lifecycle binary works on this platform
-          docker run --rm ${image_tag} arch
-          docker run --rm ${image_tag} /cnb/lifecycle/lifecycle -version
-          RUN_EOF
-          TEST-MULTI-ARCH-BUILDER-EOF
+                  - <<TEST-DOCKERFILE-EOF
+          FROM ${image_tag}
+          RUN arch && /cnb/lifecycle/lifecycle -version
+          TEST-DOCKERFILE-EOF
 
           done

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # github-actions
 Custom GitHub Actions
+
+# GitHub Actions
+
+`github-actions` is a collection of [GitHub Actions][gha] for different projects.
+
+[gha]: https://docs.github.com/en/free-pro-team@latest/actions
+
+- [GitHub Actions](#github-actions)
+  - [Buildpacks](#buildpacks)
+    - [Create Multi-arch Builders](#create-multi-arch-builders)
+
+## Buildpacks
+
+### Create Multi-arch Builders
+The `buildpacks/create-multi-arch-builders` action parses `builder-<tag>.toml` files in the given `path` and for each file it creates a multi-arch (amd64, arm64) builder image and publishes them to the given `base-image-uri` with `<tag>` as the tag.
+
+```yaml
+uses: jericop/github-actions/buildpacks/create-multi-arch-builders@v0.0.1
+with:
+  path: 'my-custom-builder'
+  base-image-uri: 'ttl.sh/my-custom-builder'
+```
+
+#### Inputs <!-- omit in toc -->
+| Parameter | Description
+| :-------- | :----------
+| `path` | The path containing the `builder-<tag>.toml` file(s).
+| `base-image-uri` | The base registry uri, without tag, where the multi-arch builder image(s) will be pushed.
+| `pack-version` | Optional version of [`pack`](https://github.com/buildpacks/pack) to install. Defaults to `v0.30.0-pre1`.
+| `lifecycle-version` | Optional version of [`lifecycle`](https://github.com/buildpacks/lifecycle) to install. Defaults to `v0.17.0-pre.1`.
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Custom GitHub Actions
 The `buildpacks/create-multi-arch-builders` action parses `builder-<tag>.toml` files in the given `path` and for each file it creates a multi-arch (amd64, arm64) builder image and publishes them to the given `base-image-uri` with `<tag>` as the tag.
 
 ```yaml
-uses: jericop/github-actions/buildpacks/create-multi-arch-builders@v0.0.1
+uses: jericop/github-actions/buildpacks/create-multi-arch-builders@v1.0.0
 with:
   path: 'my-custom-builder'
   base-image-uri: 'ttl.sh/my-custom-builder'

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -1,0 +1,185 @@
+name:        'Create Multi-arch Builders'
+description: 'Creates multi-arch builders using buildx. Requires docker/setup-qemu-action@v2 first'
+
+inputs:
+  path:
+    description: 'The path containing the `builder-<tag>.toml` file(s).'
+    required:    true
+  base-image-uri:
+    description: 'The base registry uri, without tag, where the multi-arch builder image(s) will be pushed.'
+    required:    true
+  pack-version:
+    description: 'The version of pack to install.'
+    required:    false
+    default:    'v0.30.0-pre1'
+  lifecycle-version:
+    description: 'The version of lifecycle to install.'
+    required:    false
+    default:    'v0.17.0-pre.1'
+
+runs:
+  using: "composite"
+  steps:
+  - name:  Create Multi-arch Builders
+    shell: bash
+    run:   |
+      #!/usr/bin/env bash set -euo pipefail
+
+      cd ${{ inputs.path }}
+
+      base_image_uri=${{ inputs.base-image-uri }}
+
+      # Gets tag from builder toml files following naming pattern `builder-<tag>.toml`
+      tags=$(ls *.toml | xargs -n1 | cut -d- -f2 | cut -d. -f1 | xargs)
+
+      # Used for installing pack from releases
+      pack_version=${{ inputs.pack-version }}
+
+      # Injected (or updated) in each builder-<tag>.toml file
+      lifecycle_version=${{ inputs.lifecycle-version }}
+
+      registry_port=5000
+      local_registry_uri="localhost:$registry_port"
+      local_registry_pack="$local_registry_uri/pack"
+      local_image_uri="$local_registry_uri/$(echo $base_image_uri | md5)"
+      buildx_builder=host-network
+
+      # Build from releases by default
+      build_pack_from_releases_dockerfile_replace=$(cat <<'PACK_FROM_RELEASES_EOF'
+      FROM curlimages/curl
+      USER root
+      RUN <<RUN_EOF
+      VERSION="REPLACE_PACK_VERSION"
+      TAR_FILENAME="pack-${VERSION}-linux.tgz"
+      RELEASES_BASE_URL="https://github.com/buildpacks/pack/releases/download"
+
+      if [ $(arch) = "aarch64" ]; then
+      TAR_FILENAME="pack-${VERSION}-linux-arm64.tgz"
+      fi
+
+      curl -fsSL -O "${RELEASES_BASE_URL}/${VERSION}/${TAR_FILENAME}"
+      tar -C /usr/local/bin/ --no-same-owner -xzv -f "$TAR_FILENAME" pack
+      rm $TAR_FILENAME
+      RUN_EOF
+
+      ENTRYPOINT ["/usr/local/bin/pack"]
+      PACK_FROM_RELEASES_EOF
+      )
+      build_pack_dockerfile=$(echo "$build_pack_from_releases_dockerfile_replace" | sed "s/REPLACE_PACK_VERSION/$pack_version/")
+
+      # Or build from source if PACK_REPO_URI and PACK_REPO_BRANCH environment variables have been set
+      if [[ ! -z "${PACK_REPO_URI:-}" && ! -z "${PACK_REPO_BRANCH:-}" ]]; then
+      # can't indent because of heredoc
+      build_pack_dockerfile=$(cat <<PACK_FROM_SOURCE_EOF
+      FROM golang:1.19 as builder
+      WORKDIR /workspace/pack
+      RUN git clone $PACK_REPO_URI /workspace/pack && git checkout $PACK_REPO_BRANCH
+      RUN make mod-tidy build
+
+      FROM ubuntu:jammy
+      RUN apt-get update && apt-get install -y ca-certificates
+      COPY --from=builder /workspace/pack/out/pack /usr/local/bin/pack
+      ENTRYPOINT ["/usr/local/bin/pack"]
+      PACK_FROM_SOURCE_EOF
+      )
+      fi
+
+      echo "Creating multi-arch builder image $base_image_uri with the following tags: $tags"
+
+      # Create buildx builder with access to host network (if not already created)
+      docker buildx use $buildx_builder || docker buildx create --name $buildx_builder --driver-opt network=host --use
+
+      # Start local registry (if not already running)
+      docker container inspect registry > /dev/null 2>&1 || docker run -d -p $registry_port:$registry_port --restart=always --name registry registry:2
+
+      # Create custom multi-arch pack image because the `buildpacksio/pack` image does not contain stand-alone binary
+      docker buildx build \
+          --tag $local_registry_pack \
+          --platform linux/amd64,linux/arm64 \
+          --push - <<PACK_EOF
+      $build_pack_dockerfile
+      PACK_EOF
+
+      # Write dockerfile for creating architecture-specific builders
+      # This is needed in order to copy the toml files into the container at build time
+      cat <<CREATE_ARCH_BUILDERS_DOCKERFILE_EOF > create-arch-builders.Dockerfile
+      FROM ghcr.io/jericop/go-arch as go-arch
+      FROM $local_registry_pack as pack
+
+      FROM ghcr.io/jericop/build-jammy
+      USER root
+      COPY --from=go-arch /usr/local/bin/go-arch /usr/local/bin/go-arch
+      COPY --from=pack /usr/local/bin/pack /usr/local/bin/pack
+
+      COPY *.toml ./
+      RUN <<RUN_EOF
+
+      arch_=amd64
+      lifecycle_arch=x86-64
+
+      if [ \$(arch) = "aarch64" ]; then
+        arch_=arm64
+        lifecycle_arch=arm64
+      fi
+
+      echo runtime.GOARCH
+      go-arch
+
+      echo pack version
+      pack version
+
+      for tag in $tags; do
+          # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
+          # TODO: fix this
+          lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
+          cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
+          mv updated.toml "builder-\${tag}.toml"
+
+          pack builder create "${local_image_uri}:\${tag}-\${arch_}" --config "builder-\${tag}.toml" --publish
+      done
+
+      RUN_EOF
+      CREATE_ARCH_BUILDERS_DOCKERFILE_EOF
+
+
+      # Create architecture-specific builders with pack (through buildx) and publish them to the local registry with pack.
+      # The buildx `--push` flag is not used because pack pushes the images with the `--publish` flag
+      docker buildx build \
+          --platform linux/amd64,linux/arm64 \
+          --tag not-pushing-with-buildx-so-this-is-ignored \
+          --progress plain \
+          --file create-arch-builders.Dockerfile .
+
+      rm create-arch-builders.Dockerfile
+
+
+      # Now we can create the multi-arch builders in the local registry using the architecture-specific builders created above
+      # Ultimately the multi-arch builders in the local registry will be used to create the final multi-arch iamge in $base_image_uri.
+      for tag in $tags; do
+          local_image_tag="${local_image_uri}:${tag}"
+          image_tag="${base_image_uri}:${tag}"
+
+          # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
+          # so we need this workaround to fix the platform value for arm64 images
+          # TODO: fix this
+          echo "FROM ${local_image_tag}-arm64" > Dockerfile
+          docker pull -q "${local_image_tag}-arm64"
+          docker buildx build -q --platform linux/arm64 -t "${local_image_tag}-arm64" --push .
+          docker image rm "${local_image_tag}-arm64"
+
+          # Create a multi-arch image in the local registry first
+          docker buildx imagetools create -t "${local_image_tag}" "${local_image_tag}-arm64" "${local_image_tag}-amd64"
+          docker buildx imagetools inspect "${local_image_tag}"
+          
+          # Create a dockerfile that pulls the multi-arch image from the local registry
+          # in order to create the multi-arch image in the desired registry
+          echo "FROM ${local_image_tag}" > multi-arch-builder.Dockerfile
+          
+          docker buildx build \
+              --platform linux/arm64,linux/amd64 \
+              --tag "${image_tag}" --push \
+              --file multi-arch-builder.Dockerfile .
+          docker buildx imagetools inspect "${image_tag}"
+          
+          rm multi-arch-builder.Dockerfile
+      done

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -41,7 +41,7 @@ runs:
       registry_port=5000
       local_registry_uri="localhost:$registry_port"
       local_registry_pack="$local_registry_uri/pack"
-      local_image_uri="$local_registry_uri/$(echo $base_image_uri | md5)"
+      local_image_uri="$local_registry_uri/$(echo $base_image_uri | git hash-object --stdin -w)"
       buildx_builder=host-network
 
       # Build from releases by default

--- a/buildpacks/create-multi-arch-builders/testdata/builder-latest.toml
+++ b/buildpacks/create-multi-arch-builders/testdata/builder-latest.toml
@@ -1,0 +1,14 @@
+description = "Includes deprecated stack (for backward compatibility) and build and run images which set CNB_TARGET env variables during builds"
+
+[stack]
+  id = "io.buildpacks.stacks.jericop.jammy"
+  build-image = "ghcr.io/jericop/build-jammy:latest"
+  run-image = "ghcr.io/jericop/run-jammy:latest"
+
+[build]
+image = "ghcr.io/jericop/build-jammy:latest"
+
+
+[run]
+[[run.images]]
+image = "ghcr.io/jericop/run-jammy:latest"

--- a/buildpacks/create-multi-arch-builders/testdata/builder-stack.toml
+++ b/buildpacks/create-multi-arch-builders/testdata/builder-stack.toml
@@ -1,0 +1,6 @@
+description = "Uses deprecated stack only"
+
+[stack]
+  id = "io.buildpacks.stacks.jericop.jammy"
+  build-image = "ghcr.io/jericop/build-jammy:stack"
+  run-image = "ghcr.io/jericop/run-jammy:stack"

--- a/buildpacks/create-multi-arch-builders/testdata/builder-target.toml
+++ b/buildpacks/create-multi-arch-builders/testdata/builder-target.toml
@@ -1,0 +1,8 @@
+description = "Includes build and run images which set CNB_TARGET env variables during builds. Does not set deprecated stack"
+
+[build]
+image = "ghcr.io/jericop/build-jammy:target"
+
+[run]
+[[run.images]]
+image = "ghcr.io/jericop/run-jammy:target"


### PR DESCRIPTION
Add buildpacks action for creating multi-arch-builders using buildx.

At the time of this commit, [pack](https://github.com/buildpacks/pack) does not support creating multi-arch builders. This action uses a local registry and buildx to create and publish multi-arch builder images. 

It expects that build and run images defined in `builder-<tag>.toml` files are using multi-arch images for `linux/amd64` and `linux/arm64` platforms.

See [jericop/cnb](https://github.com/jericop/cnb-base)
