### PR TITLE
Use PAT for auto tagger

### DIFF
--- a/.github/workflows/auto-tagger.yml
+++ b/.github/workflows/auto-tagger.yml
@@ -10,8 +10,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        # https://github.com/semantic-release/semantic-release/discussions/2557
+        persist-credentials: false
     - name: Github PR Auto Tagger
       uses: RueLaLa/auto-tagger@v2.1.3
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.AUTO_TAGGER_TOKEN }}
         GITHUB_PR_NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
Branch protection rules prevent pushing tag after merging

See below links for more info:

https://github.com/semantic-release/semantic-release/discussions/2557

https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch