### PR TITLE
Add matrix test on different arch runners

### DIFF
--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+      - uses: jericop/buildpacks-github-actions/setup-tools@add-arm64-support
       - id: image-uri
         run: echo "uri=ttl.sh/${{ github.repository }}/$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
       - id: create-multi-arch-builders

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -92,7 +92,8 @@ jobs:
 
           pack version
 
-          for tag in ${{ needs.ttl-sh.outputs.tags }}; do
+          # test stack tag only
+          for tag in stack; do
 
             # Full support for targets withcout staks has not landed yet, so skipping test for it (missing run images)
             # TODO: this is because run images are not stored in builder metadata when not using stack

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   # Use un-authenticated ephemeral registry image uri for testing
   ttl-sh:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
     outputs:
       uri: ${{ steps.image-uri.outputs.uri }}
       tags: ${{ steps.create-multi-arch-builders.outputs.tags }}

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -30,7 +30,7 @@ jobs:
           set -x
 
           for tag in $tags; do
-              image_tag="${{ needs.ttl-sh.outputs.uri }}:${tag}"
+              image_tag="${{ steps.image-uri.outputs.uri }}:${tag}"
               docker buildx build \
                   --platform linux/amd64,linux/arm64 \
                   --tag not-pushing-so-this-is-ignored \

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -5,7 +5,7 @@ env:
 jobs:
   # Use un-authenticated ephemeral registry image uri for testing
   ttl-sh:
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
+    runs-on: ubuntu-22.04
     outputs:
       uri: ${{ steps.image-uri.outputs.uri }}
       tags: ${{ steps.create-multi-arch-builders.outputs.tags }}

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -8,22 +8,19 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       uri: ${{ steps.image-uri.outputs.uri }}
-    steps:
-      - id: image-uri
-        run: echo "uri=ttl.sh/${{ github.repository }}/$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
-  test:
-    runs-on: ubuntu-22.04
-    needs: [ttl-sh]
+      tags: ${{ steps.create-multi-arch-builders.outputs.tags }}
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+      - id: image-uri
+        run: echo "uri=ttl.sh/${{ github.repository }}/$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
       - id: create-multi-arch-builders
         uses: ./buildpacks/create-multi-arch-builders
         with:
           path: 'buildpacks/create-multi-arch-builders/testdata'
           base-image-uri: ${{ needs.ttl-sh.outputs.uri }}
-      - name: Test mulit-arch builders
+      - name: Test lifecycle
         run: |
           #!/usr/bin/env bash -euo pipefail
 
@@ -37,9 +34,78 @@ jobs:
               docker buildx build \
                   --platform linux/amd64,linux/arm64 \
                   --tag not-pushing-so-this-is-ignored \
+                  --progress plain \
                   - <<TEST-DOCKERFILE-EOF
+          FROM ghcr.io/jericop/go-arch as go-arch
           FROM ${image_tag}
+          USER root
+          COPY --from=go-arch /usr/local/bin/go-arch /usr/local/bin/go-arch
+          RUN arch
+          RUN go-arch
           RUN /cnb/lifecycle/lifecycle -version
           TEST-DOCKERFILE-EOF
 
+          done
+
+  app-build-test:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, buildjet-4vcpu-ubuntu-2204-arm]
+    runs-on: ${{ matrix.os }}
+    needs: ttl-sh
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jericop/buildpacks-github-actions/setup-pack@add-arm64-support
+        with:
+          pack-version: 0.30.0-pre1
+      - uses: jericop/buildpacks-github-actions/setup-tools@add-arm64-support
+      - name: Build test app
+        shell: bash
+        run: |
+          #!/usr/bin/env bash -euo pipefail
+
+          set -x
+
+          base_image_uri=${{ needs.ttl-sh.outputs.uri }}
+
+          if [[ ! -d samples ]]; then git clone https://github.com/buildpacks/samples.git; fi
+
+          cd samples/apps/bash-script/bash-script-buildpack
+          mv buildpack.toml original.toml
+
+          cat original.toml
+
+          # Allow any stack to be used and add targets
+          cat original.toml | yj -tj | jq '. + {stacks: [{id: "*"}]} + {targets:[{os: "linux", arch: "amd64"}, {os: "linux", arch: "arm64"}]}' | yj -jt > buildpack.toml
+          rm original.toml
+
+          cat buildpack.toml
+
+          # Print env to see CNB_TARGET environment variables
+          # As outlined here: https://github.com/buildpacks/spec/pull/336/files
+          if ! grep -q ^env$ bin/build ; then
+            echo "echo \"Environment variables set during the build\"" >> bin/build
+            echo "env" >> bin/build
+          fi
+
+          cd ..
+
+          pack version
+
+          for tag in ${{ needs.ttl-sh.outputs.tags }}; do
+
+            # Full support for targets withcout staks has not landed yet, so skipping test for it (missing run images)
+            # TODO: this is because run images are not stored in builder metadata when not using stack
+            if [ "$tag" = "target" ]; then
+              continue
+            fi
+
+            builder_image_tag="${base_image_uri}:${tag}"
+
+            # Verify lifecycle binary works on this platform
+            docker run --rm "${builder_image_tag}" arch
+            docker run --rm "${builder_image_tag}" /cnb/lifecycle/lifecycle -version
+
+            # Build an app with the the multi-arch builder
+            pack build "sample-bash-script-app:${tag}" --builder "${builder_image_tag}"
           done

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -40,6 +40,7 @@ jobs:
           FROM ${image_tag}
           USER root
           COPY --from=go-arch /usr/local/bin/go-arch /usr/local/bin/go-arch
+          RUN uname -a
           RUN arch
           RUN go-arch
           RUN /cnb/lifecycle/lifecycle -version

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -92,6 +92,8 @@ jobs:
 
           cd ..
 
+          uname -a
+          arch
           pack version
 
           # test stack tag only
@@ -106,8 +108,9 @@ jobs:
             builder_image_tag="${base_image_uri}:${tag}"
 
             # Verify lifecycle binary works on this platform
-            docker run --rm "${builder_image_tag}" arch
+            docker pull -q "${builder_image_tag}"
             docker run --rm "${builder_image_tag}" /cnb/lifecycle/lifecycle -version
+            docker run --rm "${builder_image_tag}" arch
 
             # Build an app with the the multi-arch builder
             pack build "sample-bash-script-app:${tag}" --builder "${builder_image_tag}"

--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./buildpacks/create-multi-arch-builders
         with:
           path: 'buildpacks/create-multi-arch-builders/testdata'
-          base-image-uri: ${{ needs.ttl-sh.outputs.uri }}
+          base-image-uri: ${{ steps.image-uri.outputs.uri }}
       - name: Test lifecycle
         run: |
           #!/usr/bin/env bash -euo pipefail

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with:
 | `path` | The path containing the `builder-<tag>.toml` file(s).
 | `base-image-uri` | The base registry uri, without tag, where the multi-arch builder image(s) will be pushed.
 | `pack-version` | Optional version of [`pack`](https://github.com/buildpacks/pack) to install. Defaults to `v0.30.0-pre1`.
-| `lifecycle-version` | Optional version of [`lifecycle`](https://github.com/buildpacks/lifecycle) to install. Defaults to `v0.17.0-pre.1`.
+| `lifecycle-version` | Optional version of [`lifecycle`](https://github.com/buildpacks/lifecycle) to install. Defaults to `v0.16.0`.
 | `push` | Optional boolean string to push the multi-arch image(s) to `base-image-uri`. Defaults to `true`.
 
 #### Outputs <!-- omit in toc -->

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -162,6 +162,7 @@ runs:
       RUN_EOF
       CREATE_ARCH_BUILDERS_DOCKERFILE_EOF
 
+      set -x
 
       # Create architecture-specific builders with pack (through buildx) and publish them to the local registry with pack.
       # The buildx `--push` flag is not used because pack pushes the images with the `--publish` flag

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -151,15 +151,16 @@ runs:
 
       for tag in $tags; do
           local_image_tag="${local_image_uri}:\${tag}-\${arch_}"
+
           # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
           # TODO: fix this
-          lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
-          cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
-          mv updated.toml "builder-\${tag}.toml"
-
-          pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml" --publish
+          # lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
+          # cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
+          # mv updated.toml "builder-\${tag}.toml"
 
           if [ $(arch) = "aarch64" ]; then
+            pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml"
+
             # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
             # so we need this workaround to fix the platform value for arm64 images
             # TODO: fix this
@@ -167,6 +168,8 @@ runs:
             docker pull -q "\${local_image_tag}"
             docker buildx build -q --platform linux/arm64 -t "\${local_image_tag}" --push .
             docker image rm "\${local_image_tag}"
+          else
+            pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml" --publish
           fi
       done
 

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -97,9 +97,6 @@ runs:
       )
       fi
 
-      # Create buildx builder with access to host network (if not already created)
-      docker buildx use $buildx_builder || docker buildx create --name $buildx_builder --driver-opt network=host --use
-
       # Start local registry (if not already running)
       docker container inspect registry > /dev/null 2>&1 || docker run -d -p $registry_port:$registry_port --restart=always --name registry registry:2
 
@@ -124,6 +121,7 @@ runs:
 
       COPY *.toml ./
       RUN <<RUN_EOF
+      set -x
 
       arch_=amd64
       lifecycle_arch=x86-64

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -191,27 +191,25 @@ runs:
         # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
         # so we need this workaround to fix the platform value for arm64 images
         if [ "$(crane config ${local_image_tag}-arm64 | jq .architecture -r)" = "amd64" ]; then
-          tarfile="${tag}-invalid-arch.tar"
-          extracted="${tag}-invalid-arch"
-          updated_tarfile="${tag}-updated-arch.tar"
-
-          docker pull --platform linux/amd64 -q ${local_image_tag}-arm64
-          docker save ${local_image_tag}-arm64 -o $tarfile
-
-          mkdir -p $extracted
-          tar -C $extracted -xf $tarfile
-          cd $extracted
-          config_json="$(cat manifest.json | jq '.[0].Config' -r)"
-          cat $config_json | jq '. += {architecture: "arm64"}' > arm64.json
-          mv arm64.json $config_json
-          cd ..
-          tar -C $extracted -cf $updated_tarfile $(ls $extracted)
-
-          docker load -i $updated_tarfile
-          docker inspect "${local_image_tag}-arm64" | jq  '.[0].Architecture'
-          docker push -q "${local_image_tag}-arm64"
           crane config "${local_image_tag}-arm64" | jq .architecture
-          rm -rf $extracted $tarfile $updated_tarfile
+          crane ls "${local_image_uri}"
+
+          build_image=""
+          if cat "builder-${tag}.toml" | grep build-image; then
+              build_image=$(cat builder-${tag}.toml | yj -tj | jq '.stack["build-image"]' -r)
+          else
+              build_image=$(cat builder-${tag}.toml | yj -tj | jq .build.image -r)
+          fi
+
+          crane ls "$(echo $build_image | cut -d: -f1)"
+
+          crane rebase "${local_image_tag}-arm64" \
+              --platform linux/arm64 \
+              --old_base "${build_image}-amd64" \
+              --new_base "${build_image}-arm64" \
+              --tag "${local_image_tag}-arm64"
+
+          crane config "${local_image_tag}-arm64" | jq .architecture
         fi
 
         # Create a multi-arch image in the local registry first

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -195,6 +195,7 @@ runs:
           extracted="${tag}-invalid-arch"
           updated_tarfile="${tag}-updated-arch.tar"
 
+          docker pull -q ${local_image_tag}-arm64
           docker save ${local_image_tag}-arm64 -o $tarfile
 
           mkdir -p $extracted

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -100,13 +100,17 @@ runs:
       # Create buildx builder with access to host network (if not already created)
       docker buildx use $buildx_builder || docker buildx create --name $buildx_builder --driver-opt network=host --use
 
+      docker run --privileged --rm tonistiigi/binfmt --install all
+      docker run --rm arm64v8/alpine uname -a
+
       # Start local registry (if not already running)
       docker container inspect registry > /dev/null 2>&1 || docker run -d -p $registry_port:$registry_port --restart=always --name registry registry:2
 
-      echo "Running containers"
-      docker ps
       echo "Downloaded images"
       docker image ls
+
+      echo "Running containers"
+      docker ps
 
       # Create custom multi-arch pack image because the `buildpacksio/pack` image does not contain stand-alone binary
       docker buildx build \

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -191,16 +191,26 @@ runs:
         # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
         # so we need this workaround to fix the platform value for arm64 images
         if [ "$(crane config ${local_image_tag}-arm64 | jq .architecture -r)" = "amd64" ]; then
-          docker pull -q --platform linux/amd64 "${local_image_tag}-arm64"
-          docker tag "${local_image_tag}-arm64" "${local_image_tag}-arm64-invalid-arch"
-          docker inspect "${local_image_tag}-arm64-invalid-arch" | jq  '.[0].Architecture'
-          docker push "${local_image_tag}-arm64-invalid-arch"
-          docker image rm "${local_image_tag}-arm64"
-          echo "FROM ${local_image_tag}-arm64-invalid-arch" > Dockerfile
-          docker build -q --platform linux/arm64 -t "${local_image_tag}-arm64" .
+          tarfile="${tag}-invalid-arch.tar"
+          extracted="${tag}-invalid-arch"
+          updated_tarfile="${tag}-updated-arch.tar"
+
+          docker save ${local_image_tag}-arm64 -o $tarfile
+
+          mkdir -p $extracted
+          tar -C $extracted -xf $tarfile
+          cd $extracted
+          config_json="$(cat manifest.json | jq '.[0].Config' -r)"
+          cat $config_json | jq '. += {architecture: "arm64"}' > arm64.json
+          mv arm64.json $config_json
+          cd ..
+          tar -C $extracted -cf $updated_tarfile $(ls $extracted)
+
+          docker load -i $updated_tarfile
           docker inspect "${local_image_tag}-arm64" | jq  '.[0].Architecture'
-          docker push "${local_image_tag}-arm64"
+          docker push -q "${local_image_tag}-arm64"
           crane config "${local_image_tag}-arm64" | jq .architecture
+          rm -rf $extracted $tarfile $updated_tarfile
         fi
 
         # Create a multi-arch image in the local registry first

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -195,7 +195,7 @@ runs:
           extracted="${tag}-invalid-arch"
           updated_tarfile="${tag}-updated-arch.tar"
 
-          docker pull -q ${local_image_tag}-arm64
+          docker pull --platform linux/amd64 -q ${local_image_tag}-arm64
           docker save ${local_image_tag}-arm64 -o $tarfile
 
           mkdir -p $extracted

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -150,27 +150,13 @@ runs:
       pack version
 
       for tag in $tags; do
-          local_image_tag="${local_image_uri}:\${tag}-\${arch_}"
-
           # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
           # TODO: fix this
-          # lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
-          # cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
-          # mv updated.toml "builder-\${tag}.toml"
+          lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
+          cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
+          mv updated.toml "builder-\${tag}.toml"
 
-          if [ $(arch) = "aarch64" ]; then
-            pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml"
-
-            # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
-            # so we need this workaround to fix the platform value for arm64 images
-            # TODO: fix this
-            echo "FROM \${local_image_tag}" > Dockerfile
-            docker pull -q "\${local_image_tag}"
-            docker buildx build -q --platform linux/arm64 -t "\${local_image_tag}" --push .
-            docker image rm "\${local_image_tag}"
-          else
-            pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml" --publish
-          fi
+          pack builder create "${local_image_uri}:\${tag}-\${arch_}" --config "builder-\${tag}.toml" --publish
       done
 
       RUN_EOF
@@ -193,6 +179,15 @@ runs:
       for tag in $tags; do
           local_image_tag="${local_image_uri}:${tag}"
           image_tag="${base_image_uri}:${tag}"
+
+          # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
+          # so we need this workaround to fix the platform value for arm64 images
+          docker pull -q "${local_image_tag}-arm64"
+          docker tag "${local_image_tag}-arm64" "${local_image_tag}-arm64-broken"
+          docker push "${local_image_tag}-arm64-broken"
+          echo "FROM ${local_image_tag}-arm64-broken" > Dockerfile
+          docker build -q --platform linux/arm64 -t "${local_image_tag}-arm64" .
+          docker push "${local_image_tag}-arm64"
 
           # Create a multi-arch image in the local registry first
           docker buildx imagetools create -t "${local_image_tag}" "${local_image_tag}-arm64" "${local_image_tag}-amd64"

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -150,13 +150,24 @@ runs:
       pack version
 
       for tag in $tags; do
+          local_image_tag="${local_image_uri}:\${tag}-\${arch_}"
           # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
           # TODO: fix this
           lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
           cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
           mv updated.toml "builder-\${tag}.toml"
 
-          pack builder create "${local_image_uri}:\${tag}-\${arch_}" --config "builder-\${tag}.toml" --publish
+          pack builder create "\${local_image_tag}" --config "builder-\${tag}.toml" --publish
+
+          if [ $(arch) = "aarch64" ]; then
+            # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
+            # so we need this workaround to fix the platform value for arm64 images
+            # TODO: fix this
+            echo "FROM \${local_image_tag}" > Dockerfile
+            docker pull -q "\${local_image_tag}"
+            docker buildx build -q --platform linux/arm64 -t "\${local_image_tag}" --push .
+            docker image rm "\${local_image_tag}"
+          fi
       done
 
       RUN_EOF
@@ -179,14 +190,6 @@ runs:
       for tag in $tags; do
           local_image_tag="${local_image_uri}:${tag}"
           image_tag="${base_image_uri}:${tag}"
-
-          # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
-          # so we need this workaround to fix the platform value for arm64 images
-          # TODO: fix this
-          echo "FROM ${local_image_tag}-arm64" > Dockerfile
-          docker pull -q "${local_image_tag}-arm64"
-          docker buildx build -q --platform linux/arm64 -t "${local_image_tag}-arm64" --push .
-          docker image rm "${local_image_tag}-arm64"
 
           # Create a multi-arch image in the local registry first
           docker buildx imagetools create -t "${local_image_tag}" "${local_image_tag}-arm64" "${local_image_tag}-amd64"

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -97,8 +97,16 @@ runs:
       )
       fi
 
+      # Create buildx builder with access to host network (if not already created)
+      docker buildx use $buildx_builder || docker buildx create --name $buildx_builder --driver-opt network=host --use
+
       # Start local registry (if not already running)
       docker container inspect registry > /dev/null 2>&1 || docker run -d -p $registry_port:$registry_port --restart=always --name registry registry:2
+
+      echo "Running containers"
+      docker ps
+      echo "Downloaded images"
+      docker image ls
 
       # Create custom multi-arch pack image because the `buildpacksio/pack` image does not contain stand-alone binary
       docker buildx build \

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -51,10 +51,11 @@ runs:
       # Injected (or updated) in each builder-<tag>.toml file
       lifecycle_version=${{ inputs.lifecycle-version }}
 
-      registry_port=5000
-      local_registry_uri="localhost:$registry_port"
+      registry_hostname=$(echo $base_image_uri | cut -d/ -f1)
+      local_registry_port=5000
+      local_registry_uri="localhost:$local_registry_port"
       local_registry_pack="$local_registry_uri/pack"
-      local_image_uri="$local_registry_uri/$(echo $base_image_uri | git hash-object --stdin -w)"
+      local_image_uri=$(echo $base_image_uri | sed "s/$registry_hostname/$local_registry_uri/")
       buildx_builder=host-network
 
       # Build from releases by default
@@ -104,7 +105,7 @@ runs:
       docker run --rm arm64v8/alpine uname -a
 
       # Start local registry (if not already running)
-      docker container inspect registry > /dev/null 2>&1 || docker run -d -p $registry_port:$registry_port --restart=always --name registry registry:2
+      docker container inspect registry > /dev/null 2>&1 || docker run -d -p $local_registry_port:$local_registry_port --restart=always --name registry registry:2
 
       echo "Downloaded images"
       docker image ls
@@ -116,6 +117,7 @@ runs:
       docker buildx build \
           --tag $local_registry_pack \
           --platform linux/amd64,linux/arm64 \
+          --quiet \
           --push - <<PACK_EOF
       $build_pack_dockerfile
       PACK_EOF
@@ -133,6 +135,7 @@ runs:
 
       COPY *.toml ./
       RUN <<RUN_EOF
+      set -e
       set -x
 
       arch_=amd64
@@ -143,20 +146,23 @@ runs:
         lifecycle_arch=arm64
       fi
 
-      echo runtime.GOARCH
+      uname -a
       go-arch
-
-      echo pack version
       pack version
 
       for tag in $tags; do
-          # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
-          # TODO: fix this
-          lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
-          cat "builder-\${tag}.toml" | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
-          mv updated.toml "builder-\${tag}.toml"
+        local_image_tag="${local_image_uri}:\${tag}-\${arch_}"
+        builder_toml="builder-\${tag}.toml"
 
-          pack builder create "${local_image_uri}:\${tag}-\${arch_}" --config "builder-\${tag}.toml" --publish
+        # This is a workaround because pack downloads the lifecycle binary for x86-64, even on arm64.
+        # TODO: fix this
+        lifecycle_url="https://github.com/buildpacks/lifecycle/releases/download/${lifecycle_version}/lifecycle-${lifecycle_version}+linux.\${lifecycle_arch}.tgz"
+        cat \${builder_toml} | yj -tj | jq ". + {lifecycle: {uri: \"\$lifecycle_url\"}}" | yj -jt > updated.toml
+        mv updated.toml \${builder_toml}
+
+        # cat \${builder_toml}
+
+        pack builder create \${local_image_tag} --config \${builder_toml} --publish
       done
 
       RUN_EOF
@@ -178,37 +184,40 @@ runs:
       # Now we can create the multi-arch builders in the local registry using the architecture-specific builders created above
       # Ultimately the multi-arch builders in the local registry will be used to create the final multi-arch iamge in $base_image_uri.
       for tag in $tags; do
-          local_image_tag="${local_image_uri}:${tag}"
-          image_tag="${base_image_uri}:${tag}"
+        local_image_tag="${local_image_uri}:${tag}"
+        image_tag="${base_image_uri}:${tag}"
 
-          # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
-          # so we need this workaround to fix the platform value for arm64 images
-          docker pull -q "${local_image_tag}-arm64"
-          docker tag "${local_image_tag}-arm64" "${local_image_tag}-arm64-broken"
-          docker push "${local_image_tag}-arm64-broken"
-          echo "FROM ${local_image_tag}-arm64-broken" > Dockerfile
+        # As of pack version 0.30.0-pre1 publishing with `--publish` will set the platform to linux/amd64 on arm64,
+        # so we need this workaround to fix the platform value for arm64 images
+        if [ "$(crane config ${local_image_tag}-arm64 | jq .architecture -r)" = "amd64" ]; then
+          docker pull -q --platform linux/amd64 "${local_image_tag}-arm64"
+          docker tag "${local_image_tag}-arm64" "${local_image_tag}-arm64-invalid-arch"
+          docker inspect "${local_image_tag}-arm64-invalid-arch" | jq  '.[0].Architecture'
+          docker push "${local_image_tag}-arm64-invalid-arch"
+          docker image rm "${local_image_tag}-arm64"
+          echo "FROM ${local_image_tag}-arm64-invalid-arch" > Dockerfile
           docker build -q --platform linux/arm64 -t "${local_image_tag}-arm64" .
+          docker inspect "${local_image_tag}-arm64" | jq  '.[0].Architecture'
           docker push "${local_image_tag}-arm64"
+          crane config "${local_image_tag}-arm64" | jq .architecture
+        fi
 
-          # Create a multi-arch image in the local registry first
-          docker buildx imagetools create -t "${local_image_tag}" "${local_image_tag}-arm64" "${local_image_tag}-amd64"
-          docker buildx imagetools inspect "${local_image_tag}"
-          
-          if [ "${{ inputs.push }}" = "true" ]; then
-            # Create a dockerfile that pulls the multi-arch image from the local registry
-            # in order to create the multi-arch image in the desired registry
-            echo "FROM ${local_image_tag}" > multi-arch-builder.Dockerfile
-
-            docker buildx build \
-                --platform linux/arm64,linux/amd64 \
-                --tag "${image_tag}" \
-                --push \
-                --file multi-arch-builder.Dockerfile .
-            docker buildx imagetools inspect "${image_tag}"
-
-            rm multi-arch-builder.Dockerfile
-          fi
+        # Create a multi-arch image in the local registry first
+        docker buildx imagetools create -t "${local_image_tag}" "${local_image_tag}-arm64" "${local_image_tag}-amd64"
+        docker buildx imagetools inspect "${local_image_tag}"
+        
+        # Create a dockerfile that pulls the multi-arch image from the local registry
+        # in order to create the multi-arch image in the desired registry
+        echo "FROM ${local_image_tag}" > multi-arch-builder.Dockerfile
+        docker buildx build \
+          --platform linux/arm64,linux/amd64 \
+          --tag "${image_tag}" --push \
+          --file multi-arch-builder.Dockerfile .
+        docker buildx imagetools inspect "${image_tag}"
+        rm Dockerfile
       done
+
+      crane ls $local_image_uri
 
       echo "tags=$tags" >> $GITHUB_OUTPUT
       echo "local_registry_uri=$local_registry_uri" >> $GITHUB_OUTPUT

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -226,7 +226,7 @@ runs:
           --tag "${image_tag}" --push \
           --file multi-arch-builder.Dockerfile .
         docker buildx imagetools inspect "${image_tag}"
-        rm Dockerfile
+        rm multi-arch-builder.Dockerfile
       done
 
       crane ls $local_image_uri

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -180,6 +180,7 @@ runs:
 
       rm create-arch-builders.Dockerfile
 
+      crane ls $local_image_uri
 
       # Now we can create the multi-arch builders in the local registry using the architecture-specific builders created above
       # Ultimately the multi-arch builders in the local registry will be used to create the final multi-arch iamge in $base_image_uri.

--- a/buildpacks/create-multi-arch-builders/action.yaml
+++ b/buildpacks/create-multi-arch-builders/action.yaml
@@ -15,7 +15,7 @@ inputs:
   lifecycle-version:
     description: 'The version of lifecycle to install.'
     required:    false
-    default:    'v0.17.0-pre.1'
+    default:    'v0.16.0'
   push:
     description: 'Push the multi-arch image(s) to `base-image-uri`.'
     required:    false


### PR DESCRIPTION
This change:

* Adds matrix tests to verify builder works on multiple platforms
* Updates arm64 workaround to use `crane rebase` to replace amd64 images in arm64 builders.