### PR TITLE
Test crane 0.14.0 version bump

### DIFF
--- a/.github/workflows/buildpacks-create-multi-arch-builders.yml
+++ b/.github/workflows/buildpacks-create-multi-arch-builders.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
-      - uses: jericop/buildpacks-github-actions/setup-tools@add-arm64-support
+      - uses: jericop/buildpacks-github-actions/setup-tools@bump-setup-tools-crane
       - id: image-uri
         run: echo "uri=ttl.sh/${{ github.repository }}/$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
       - id: create-multi-arch-builders
@@ -57,10 +57,10 @@ jobs:
     needs: ttl-sh
     steps:
       - uses: actions/checkout@v3
-      - uses: jericop/buildpacks-github-actions/setup-pack@add-arm64-support
+      - uses: jericop/buildpacks-github-actions/setup-pack@bump-setup-tools-crane
         with:
           pack-version: 0.30.0-pre1
-      - uses: jericop/buildpacks-github-actions/setup-tools@add-arm64-support
+      - uses: jericop/buildpacks-github-actions/setup-tools@bump-setup-tools-crane
       - name: Build test app
         shell: bash
         run: |
@@ -107,6 +107,9 @@ jobs:
 
             builder_image_tag="${base_image_uri}:${tag}"
 
+            crane version
+            crane manifest $builder_image_tag
+
             # Verify lifecycle binary works on this platform
             docker pull -q "${builder_image_tag}"
             docker run --rm "${builder_image_tag}" /cnb/lifecycle/lifecycle -version
@@ -114,4 +117,6 @@ jobs:
 
             # Build an app with the the multi-arch builder
             pack build "sample-bash-script-app:${tag}" --builder "${builder_image_tag}"
+
+
           done


### PR DESCRIPTION
This tests that the following fork (and branch) work correctly for crane 0.14.0.
 jericop/buildpacks-github-actions/setup-tools@bump-setup-tools-crane